### PR TITLE
[#15] feat: 주문 조회 API

### DIFF
--- a/src/main/java/com/example/demo/common/config/QueryDslConfig.java
+++ b/src/main/java/com/example/demo/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.example.demo.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+
+}

--- a/src/main/java/com/example/demo/common/exception/Error.java
+++ b/src/main/java/com/example/demo/common/exception/Error.java
@@ -27,7 +27,8 @@ public enum Error {
 	NOT_FOUND_ORDER(5000, "해당 주문을 찾을 수 없습니다."),
 	RETURN_PERIOD_PASSED(5001, "주문을 취소할 수 없습니다."),
 	ORDER_BEEN_CANCELED(5002, "주문이 취소되었습니다."),
-	INCORRECT_TOTAL_PRICE(5200, "총 금액이 맞지않습니다."),
+	IS_NOT_YOUR_ORDER(5003, "사용자의 주문이 아닙니다."),
+	INCORRECT_TOTAL_PRICE(5100, "총 금액이 맞지않습니다."),
 
 
 	INTERNAL_SERVER_ERROR(9999, "서버 오류입니다.");

--- a/src/main/java/com/example/demo/domain/entity/Order.java
+++ b/src/main/java/com/example/demo/domain/entity/Order.java
@@ -43,12 +43,20 @@ public class Order extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	Status.Order status;
 
+	@ManyToOne
+	@JoinColumn(name = "store_id")
+	Store store;
+
 	@JsonIgnore
 	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	List<OrderDetail> orderDetailList;
 
 	public void addOrderDetail(List<OrderDetail> orderDetailList) {
 		this.orderDetailList = orderDetailList;
+	}
+
+	public void updateStatus(Status.Order status) {
+		this.status = status;
 	}
 
 }

--- a/src/main/java/com/example/demo/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/demo/domain/order/controller/OrderController.java
@@ -1,14 +1,20 @@
 package com.example.demo.domain.order.controller;
 
 import com.example.demo.common.model.response.Response;
+import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.order.controller.docs.OrderControllerDocs;
 import com.example.demo.domain.order.model.request.OrderRequestDTO;
+import com.example.demo.domain.order.model.response.OrderResponseDTO;
+import com.example.demo.domain.order.model.response.StoreOrderResponseDTO;
 import com.example.demo.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -30,13 +36,38 @@ public class OrderController implements OrderControllerDocs {
 	}
 
 	@PatchMapping("/{orderId}")
-	public Response<Void> modifyOrderStatus(@PathVariable UUID orderId) {
+	public Response<Void> modifyOrderStatus(@PathVariable UUID orderId, @RequestParam Boolean isCancel) {
 
-		orderService.modifyOrderStatus(orderId);
-		
+		orderService.modifyOrderStatus(orderId, isCancel);
+
 		return Response.<Void>builder()
-				.code(HttpStatus.OK.value())
-				.message(HttpStatus.OK.getReasonPhrase())
+				.build();
+	}
+
+	@GetMapping("/{orderId}")
+	public Response<OrderResponseDTO> getOrderDetails(@PathVariable UUID orderId, @AuthenticationPrincipal User user) {
+
+		return Response.<OrderResponseDTO>builder()
+				.data(orderService.getOrderDetails(orderId, user.getId()))
+				.build();
+	}
+
+	@GetMapping("/user")
+	public Response<List<OrderResponseDTO>> getAllOrdersByCustomer(@AuthenticationPrincipal User user) {
+
+		return Response.<List<OrderResponseDTO>>builder()
+				.data(orderService.getAllOrdersByCustomer(user.getId()))
+				.build();
+	}
+
+	@GetMapping("/store/{storeId}")
+	public Response<StoreOrderResponseDTO> getAllOrdersByStore(@PathVariable UUID storeId,
+	                                                           @RequestBody LocalDateTime startDate,
+	                                                           @RequestBody LocalDateTime endDate,
+	                                                           @AuthenticationPrincipal User user) {
+
+		return Response.<StoreOrderResponseDTO>builder()
+				.data(orderService.getAllOrdersByStore(storeId, startDate, endDate, user.getId()))
 				.build();
 	}
 }

--- a/src/main/java/com/example/demo/domain/order/controller/docs/OrderControllerDocs.java
+++ b/src/main/java/com/example/demo/domain/order/controller/docs/OrderControllerDocs.java
@@ -1,7 +1,10 @@
 package com.example.demo.domain.order.controller.docs;
 
 import com.example.demo.common.model.response.Response;
+import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.order.model.request.OrderRequestDTO;
+import com.example.demo.domain.order.model.response.OrderResponseDTO;
+import com.example.demo.domain.order.model.response.StoreOrderResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,10 +13,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Tag(name = "Order", description = "주문 생성, 주문내역 조회,수정 등의 사용자 API")
@@ -34,6 +38,31 @@ public interface OrderControllerDocs {
 			@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = Response.class)))
 	})
 	@PatchMapping("/api/v1/order/{orderId}")
-	Response<Void> modifyOrderStatus(@PathVariable UUID orderId);
+	Response<Void> modifyOrderStatus(@PathVariable UUID orderId, @RequestParam Boolean isCancel);
+
+	@Operation(summary = "주문 조회", description = "주문 ID 를 통해 주문을 조회하는 API 입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "주문 조회 성공", content = @Content(schema = @Schema(implementation = Response.class))),
+			@ApiResponse(responseCode = "404", description = "주문을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = Response.class)))
+	})
+	@GetMapping("/api/v1/order/{orderId}")
+	Response<OrderResponseDTO> getOrderDetails(@PathVariable UUID orderId, @AuthenticationPrincipal User user);
+
+	@Operation(summary = "내 주문 전체 조회", description = "사용자 ID 를 통해 주문 전체를 조회하는 API 입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "주문 조회 성공", content = @Content(schema = @Schema(implementation = Response.class)))
+	})
+	@GetMapping("/api/v1/order/user")
+	Response<List<OrderResponseDTO>> getAllOrdersByCustomer(@AuthenticationPrincipal User user);
+
+	@Operation(summary = "가게 주문 조회", description = "사용자 ID 를 통해 주문 전체를 조회하는 API 입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "주문 조회 성공", content = @Content(schema = @Schema(implementation = Response.class)))
+	})
+	@GetMapping("/api/v1/order/store/{storeId}")
+	Response<StoreOrderResponseDTO> getAllOrdersByStore(@PathVariable UUID storeId,
+	                                                    @RequestBody LocalDateTime startDate,
+	                                                    @RequestBody LocalDateTime endDate,
+	                                                    @AuthenticationPrincipal User user);
 
 }

--- a/src/main/java/com/example/demo/domain/order/exception/IsNotYourOrderException.java
+++ b/src/main/java/com/example/demo/domain/order/exception/IsNotYourOrderException.java
@@ -1,0 +1,10 @@
+package com.example.demo.domain.order.exception;
+
+import com.example.demo.common.exception.Error;
+import org.springframework.http.HttpStatus;
+
+public class IsNotYourOrderException extends OrderException {
+	public IsNotYourOrderException() {
+		super(Error.IS_NOT_YOUR_ORDER, HttpStatus.BAD_REQUEST);
+	}
+}

--- a/src/main/java/com/example/demo/domain/order/mapper/OrderMapper.java
+++ b/src/main/java/com/example/demo/domain/order/mapper/OrderMapper.java
@@ -5,7 +5,13 @@ import com.example.demo.domain.entity.Order;
 import com.example.demo.domain.entity.OrderDetail;
 import com.example.demo.domain.order.model.request.OrderDetailRequestDTO;
 import com.example.demo.domain.order.model.request.OrderRequestDTO;
+import com.example.demo.domain.order.model.response.BaseOrderDTO;
+import com.example.demo.domain.order.model.response.OrderDetailResponseDTO;
+import com.example.demo.domain.order.model.response.OrderResponseDTO;
+import com.example.demo.domain.order.model.response.StoreOrderResponseDTO;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.example.demo.domain.entity.common.Status.Order.ORDER_COMPLETED;
 import static com.example.demo.domain.entity.common.Status.Order.ORDER_PROGRESS;
@@ -34,4 +40,40 @@ public class OrderMapper {
 				.build();
 	}
 
+	public OrderResponseDTO toOrderResponseDTO(Order order) {
+
+		return new OrderResponseDTO(
+				new BaseOrderDTO(
+						order.getId(),
+						order.getTotalPrice(),
+						order.getIsTakeOut(),
+						order.getStatus().name()
+				),
+				order.getDestinationAddr(),
+				order.getOrderRequest(),
+				order.getOrderDetailList().stream().map(orderDetail ->
+						new OrderDetailResponseDTO(
+								orderDetail.getMenu().getName(),
+								orderDetail.getPrice(),
+								orderDetail.getQuantity()
+						)
+				).toList()
+		);
+	}
+
+	public StoreOrderResponseDTO toStoreOrderResponseDTO(List<Order> orderList) {
+
+		return new StoreOrderResponseDTO(
+				orderList.size(),
+				orderList.stream().mapToInt(Order::getTotalPrice).sum(),
+				orderList.stream().map(order ->
+						new BaseOrderDTO(
+								order.getId(),
+								order.getTotalPrice(),
+								order.getIsTakeOut(),
+								order.getStatus().name()
+						)
+				).toList()
+		);
+	}
 }

--- a/src/main/java/com/example/demo/domain/order/model/response/BaseOrderDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/response/BaseOrderDTO.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.order.model.response;
+
+import java.util.UUID;
+
+public record BaseOrderDTO(
+
+		UUID id,
+		Integer totalPrice,
+		Boolean isTakeOut,
+		String status
+
+) {
+}

--- a/src/main/java/com/example/demo/domain/order/model/response/OrderDetailResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/response/OrderDetailResponseDTO.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.order.model.response;
+
+public record OrderDetailResponseDTO(
+
+		String name,
+
+		Integer price,
+
+		Integer quantity
+) {
+}

--- a/src/main/java/com/example/demo/domain/order/model/response/OrderResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/response/OrderResponseDTO.java
@@ -1,0 +1,17 @@
+package com.example.demo.domain.order.model.response;
+
+import java.util.List;
+
+public record OrderResponseDTO(
+
+		BaseOrderDTO baseOrder,
+
+		String destinationAddr,
+
+		String orderRequest,
+
+		List<OrderDetailResponseDTO> orderDetailList
+
+) {
+
+}

--- a/src/main/java/com/example/demo/domain/order/model/response/StoreOrderResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/response/StoreOrderResponseDTO.java
@@ -1,0 +1,13 @@
+package com.example.demo.domain.order.model.response;
+
+import java.util.List;
+
+public record StoreOrderResponseDTO(
+
+		Integer periodOrderCount,
+
+		Integer periodTotalPrice,
+
+		List<BaseOrderDTO> orderList
+) {
+}

--- a/src/main/java/com/example/demo/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/demo/domain/order/repository/OrderRepository.java
@@ -1,9 +1,14 @@
 package com.example.demo.domain.order.repository;
 
 import com.example.demo.domain.entity.Order;
+import com.example.demo.domain.order.repository.custom.OrderRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderRepository extends JpaRepository<Order, UUID>, OrderRepositoryCustom {
+	
+	List<Order> findAllByStoreIdAndCreatedAtBetween(UUID storeId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/example/demo/domain/order/repository/StoreRepository.java
+++ b/src/main/java/com/example/demo/domain/order/repository/StoreRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.domain.order.repository;
+
+import com.example.demo.domain.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+}

--- a/src/main/java/com/example/demo/domain/order/repository/custom/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/demo/domain/order/repository/custom/OrderRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.demo.domain.order.repository.custom;
+
+import com.example.demo.domain.entity.Order;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OrderRepositoryCustom {
+
+	Order getOrderWithFullDetails(UUID orderId);
+
+	List<Order> getOrdersWithFullDetails(UUID userId);
+
+}

--- a/src/main/java/com/example/demo/domain/order/repository/custom/impl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/demo/domain/order/repository/custom/impl/OrderRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.domain.order.repository.custom.impl;
+
+import com.example.demo.domain.entity.Order;
+import com.example.demo.domain.order.repository.custom.OrderRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.example.demo.domain.entity.QMenu.menu;
+import static com.example.demo.domain.entity.QOrder.order;
+import static com.example.demo.domain.entity.QOrderDetail.orderDetail;
+
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Order getOrderWithFullDetails(UUID orderId) {
+
+		return queryFactory.selectFrom(order)
+				.leftJoin(order.orderDetailList, orderDetail)
+				.fetchJoin()
+				.leftJoin(orderDetail.menu, menu)
+				.fetchJoin()
+				.where(order.id.eq(orderId))
+				.fetchOne();
+	}
+
+	@Override
+	public List<Order> getOrdersWithFullDetails(UUID userId) {
+
+		return queryFactory.selectFrom(order)
+				.leftJoin(order.orderDetailList, orderDetail)
+				.fetchJoin()
+				.leftJoin(orderDetail.menu, menu)
+				.fetchJoin()
+				.where(order.createdBy.eq(userId))
+				.fetch();
+	}
+}

--- a/src/main/java/com/example/demo/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/demo/domain/order/service/OrderService.java
@@ -2,12 +2,17 @@ package com.example.demo.domain.order.service;
 
 import com.example.demo.domain.entity.Order;
 import com.example.demo.domain.entity.OrderDetail;
+import com.example.demo.domain.entity.Store;
 import com.example.demo.domain.order.exception.IncorrectTotalPriceException;
+import com.example.demo.domain.order.exception.IsNotYourOrderException;
 import com.example.demo.domain.order.exception.NotFoundOrderException;
 import com.example.demo.domain.order.exception.ReturnPeriodPassedException;
 import com.example.demo.domain.order.mapper.OrderMapper;
 import com.example.demo.domain.order.model.request.OrderRequestDTO;
+import com.example.demo.domain.order.model.response.OrderResponseDTO;
+import com.example.demo.domain.order.model.response.StoreOrderResponseDTO;
 import com.example.demo.domain.order.repository.OrderRepository;
+import com.example.demo.domain.order.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +21,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static com.example.demo.domain.entity.common.Status.Order.ORDER_COMPLETED;
+
 @Service
 @RequiredArgsConstructor
 public class OrderService {
 
 	private final OrderMapper orderMapper;
 	private final OrderRepository orderRepository;
+	private final StoreRepository storeRepository;
 
 	@Transactional
 	public void createOrder(OrderRequestDTO request) {
@@ -44,18 +52,65 @@ public class OrderService {
 	}
 
 	@Transactional
-	public void modifyOrderStatus(UUID orderId) {
+	public void modifyOrderStatus(UUID orderId, Boolean isCancel) {
 
 		Order order = orderRepository.findById(orderId).orElseThrow(NotFoundOrderException::new);
 
-		if (order.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5))) {
-			throw new ReturnPeriodPassedException();
-		}
+		if (isCancel) {
 
-		//TODO: (준석) deleteBy 추가하기
-		order.markAsDelete();
+			if (order.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5))) {
+				throw new ReturnPeriodPassedException();
+			}
+
+			//TODO: (준석) deleteBy 추가하기
+			order.markAsDelete();
+
+		} else {
+
+			order.updateStatus(ORDER_COMPLETED);
+		}
 
 		orderRepository.save(order);
 	}
 
+	@Transactional(readOnly = true)
+	public OrderResponseDTO getOrderDetails(UUID orderId, UUID userId) {
+
+		Order order = orderRepository.getOrderWithFullDetails(orderId);
+
+		if (!order.getCreatedBy().equals(userId)) {
+			throw new IsNotYourOrderException();
+		}
+
+		return orderMapper.toOrderResponseDTO(order);
+	}
+
+	@Transactional(readOnly = true)
+	public List<OrderResponseDTO> getAllOrdersByCustomer(UUID userId) {
+
+		List<Order> orderList = orderRepository.getOrdersWithFullDetails(userId);
+
+		return orderList.stream().map(order -> {
+
+			if (!order.getCreatedBy().equals(userId))
+				throw new IsNotYourOrderException();
+
+			return orderMapper.toOrderResponseDTO(order);
+		}).toList();
+	}
+
+	@Transactional(readOnly = true)
+	public StoreOrderResponseDTO getAllOrdersByStore(UUID storeId, LocalDateTime startDate, LocalDateTime endDate, UUID userId) {
+
+		//TODO: (준석) store 추가되면 repo, exception 수정하기
+		Store store = storeRepository.findById(storeId).orElseThrow();
+
+		if (!store.getCreatedBy().equals(userId)) {
+			throw new IllegalArgumentException();
+		}
+
+		List<Order> orderList = orderRepository.findAllByStoreIdAndCreatedAtBetween(storeId, startDate, endDate);
+
+		return orderMapper.toStoreOrderResponseDTO(orderList);
+	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [#15 ]

## 📝 Description

- 주문 단건조회, 내 주문 전체조회, 가게 주문조회 API

## 💬 To Reivewers

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 가게 주문조회 API (getAllOrdersByStore) 에서 storeRepo 임시로 만들어서 사용했습니다!
- store createBy 와 userId 가 다르면 exception 발생하는 부분, storeRepo 는 추후 지혜님이 만들어주시면 제거할게용
- 그리고,, @AuthenticationPrincipal 어노테이션 사용할까요? 아니면 그냥 request 마다 userId 전달받아 사용하는 형식으로 할까요?
