### PR TITLE
[#32, #35] feat: 사용자 리뷰 전체 조회, 가게 리뷰 전체 조회

### DIFF
--- a/src/main/java/com/example/demo/domain/order/entity/Order.java
+++ b/src/main/java/com/example/demo/domain/order/entity/Order.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "p_order")
-@ToString
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Order extends BaseEntity {
 

--- a/src/main/java/com/example/demo/domain/order/model/request/OrderDetailRequestDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/request/OrderDetailRequestDTO.java
@@ -1,6 +1,7 @@
 package com.example.demo.domain.order.model.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
@@ -9,10 +10,10 @@ public record OrderDetailRequestDTO(
 		@NotBlank
 		UUID menuId,
 
-		@NotBlank
+		@NotNull
 		Integer price,
 
-		@NotBlank
+		@NotNull
 		Integer quantity
 
 ) {

--- a/src/main/java/com/example/demo/domain/order/model/request/OrderRequestDTO.java
+++ b/src/main/java/com/example/demo/domain/order/model/request/OrderRequestDTO.java
@@ -1,12 +1,13 @@
 package com.example.demo.domain.order.model.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record OrderRequestDTO(
 
-		@NotBlank(message = "총 가격을 입력해주세요.")
+		@NotNull(message = "총 가격을 입력해주세요.")
 		Integer totalPrice,
 
 		@NotBlank(message = "도착지를 입력해주세요.")
@@ -14,7 +15,7 @@ public record OrderRequestDTO(
 
 		String orderRequest,
 
-		@NotBlank(message = "포장 여부를 입력해주세요.")
+		@NotNull(message = "포장 여부를 입력해주세요.")
 		Boolean isTakeOut,
 
 		String status,

--- a/src/main/java/com/example/demo/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/demo/domain/review/controller/ReviewController.java
@@ -4,7 +4,7 @@ import com.example.demo.common.model.response.Response;
 import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.review.controller.docs.ReviewControllerDocs;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
-import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
+import com.example.demo.domain.review.model.response.ReviewListResponseDTO;
 import com.example.demo.domain.review.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,12 +38,21 @@ public class ReviewController implements ReviewControllerDocs {
 				.build();
 	}
 
-	@GetMapping("/{userId}")
-	public Response<UserReviewResponseDTO> getReviewList(@PathVariable UUID userId,
-	                                                     @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-	                                                     Pageable pageable) {
-		return Response.<UserReviewResponseDTO>builder()
-				.data(reviewService.getReviewList(userId, pageable))
+	@GetMapping("/user/{userId}")
+	public Response<ReviewListResponseDTO> getUserReviewList(@PathVariable UUID userId,
+	                                                         @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+	                                                         Pageable pageable) {
+		return Response.<ReviewListResponseDTO>builder()
+				.data(reviewService.getUserReviewList(userId, pageable))
+				.build();
+	}
+
+	@GetMapping("/store/{storeId}")
+	public Response<ReviewListResponseDTO> getStoreReviewList(@PathVariable UUID storeId,
+	                                                          @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+	                                                          Pageable pageable) {
+		return Response.<ReviewListResponseDTO>builder()
+				.data(reviewService.getStoreReviewList(storeId, pageable))
 				.build();
 	}
 }

--- a/src/main/java/com/example/demo/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/demo/domain/review/controller/ReviewController.java
@@ -4,9 +4,13 @@ import com.example.demo.common.model.response.Response;
 import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.review.controller.docs.ReviewControllerDocs;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
+import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
 import com.example.demo.domain.review.service.ReviewService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +35,15 @@ public class ReviewController implements ReviewControllerDocs {
 	public Response<Void> modifyReviewStatus(@PathVariable UUID reviewId, @AuthenticationPrincipal User user) {
 		reviewService.modifyReviewStatus(reviewId, user.getId());
 		return Response.<Void>builder()
+				.build();
+	}
+
+	@GetMapping("/{userId}")
+	public Response<UserReviewResponseDTO> getReviewList(@PathVariable UUID userId,
+	                                                     @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+	                                                     Pageable pageable) {
+		return Response.<UserReviewResponseDTO>builder()
+				.data(reviewService.getReviewList(userId, pageable))
 				.build();
 	}
 }

--- a/src/main/java/com/example/demo/domain/review/controller/docs/ReviewControllerDocs.java
+++ b/src/main/java/com/example/demo/domain/review/controller/docs/ReviewControllerDocs.java
@@ -3,6 +3,7 @@ package com.example.demo.domain.review.controller.docs;
 import com.example.demo.common.model.response.Response;
 import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
+import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,7 +12,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +46,13 @@ public interface ReviewControllerDocs {
 	})
 	@PatchMapping("/api/v1/review/{reviewId}")
 	Response<Void> modifyReviewStatus(@PathVariable UUID reviewId, @AuthenticationPrincipal User user);
+
+	@Operation(summary = "사용자 리뷰 조회", description = "사용자 ID 를 통해 작성한 리뷰를 조회하는 API 입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "리뷰 조회 성공", content = @Content(schema = @Schema(implementation = Response.class))),
+			@ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = Response.class)))
+	})
+	@GetMapping("/api/v1/review/{userId}")
+	Response<UserReviewResponseDTO> getReviewList(@PathVariable UUID userId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/demo/domain/review/controller/docs/ReviewControllerDocs.java
+++ b/src/main/java/com/example/demo/domain/review/controller/docs/ReviewControllerDocs.java
@@ -3,7 +3,7 @@ package com.example.demo.domain.review.controller.docs;
 import com.example.demo.common.model.response.Response;
 import com.example.demo.domain.entity.user.User;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
-import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
+import com.example.demo.domain.review.model.response.ReviewListResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -52,7 +52,15 @@ public interface ReviewControllerDocs {
 			@ApiResponse(responseCode = "200", description = "리뷰 조회 성공", content = @Content(schema = @Schema(implementation = Response.class))),
 			@ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = Response.class)))
 	})
-	@GetMapping("/api/v1/review/{userId}")
-	Response<UserReviewResponseDTO> getReviewList(@PathVariable UUID userId, Pageable pageable);
+	@GetMapping("/api/v1/review/user/{userId}")
+	Response<ReviewListResponseDTO> getUserReviewList(@PathVariable UUID userId, Pageable pageable);
+
+	@Operation(summary = "가게 리뷰 조회", description = "가게 ID 를 통해 작성된 리뷰를 조회하는 API 입니다.")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "리뷰 조회 성공", content = @Content(schema = @Schema(implementation = Response.class))),
+			@ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = Response.class)))
+	})
+	@GetMapping("/api/v1/review/store/{storeId}")
+	Response<ReviewListResponseDTO> getStoreReviewList(@PathVariable UUID storeId, Pageable pageable);
 
 }

--- a/src/main/java/com/example/demo/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/example/demo/domain/review/mapper/ReviewMapper.java
@@ -3,6 +3,7 @@ package com.example.demo.domain.review.mapper;
 import com.example.demo.domain.order.entity.Order;
 import com.example.demo.domain.review.entity.Review;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
+import com.example.demo.domain.review.model.response.ReviewResponseDTO;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,5 +16,13 @@ public class ReviewMapper {
 				.content(request.base().content())
 				.rating(request.base().rating())
 				.build();
+	}
+
+	public ReviewResponseDTO toReviewResponseDTO(Review review) {
+		return new ReviewResponseDTO(
+				review.getContent(),
+				review.getRating(),
+				review.getImageUrl()
+		);
 	}
 }

--- a/src/main/java/com/example/demo/domain/review/model/response/ReviewListResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/review/model/response/ReviewListResponseDTO.java
@@ -2,7 +2,7 @@ package com.example.demo.domain.review.model.response;
 
 import java.util.List;
 
-public record UserReviewResponseDTO(
+public record ReviewListResponseDTO(
 
 		Integer totalElements,
 

--- a/src/main/java/com/example/demo/domain/review/model/response/ReviewResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/review/model/response/ReviewResponseDTO.java
@@ -1,0 +1,11 @@
+package com.example.demo.domain.review.model.response;
+
+public record ReviewResponseDTO(
+
+		String content,
+
+		Integer rating,
+
+		String imageUrl
+) {
+}

--- a/src/main/java/com/example/demo/domain/review/model/response/UserReviewResponseDTO.java
+++ b/src/main/java/com/example/demo/domain/review/model/response/UserReviewResponseDTO.java
@@ -1,0 +1,12 @@
+package com.example.demo.domain.review.model.response;
+
+import java.util.List;
+
+public record UserReviewResponseDTO(
+
+		Integer totalElements,
+
+		List<ReviewResponseDTO> reviewList
+
+) {
+}

--- a/src/main/java/com/example/demo/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/demo/domain/review/repository/ReviewRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 	Page<Review> findAllByCreatedBy(UUID userId, Pageable pageable);
+
+	Page<Review> findAllByIsDeleteTrueAndIsPublicFalseAndOrderStoreId(UUID storeId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/demo/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,12 @@
 package com.example.demo.domain.review.repository;
 
 import com.example.demo.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
+	Page<Review> findAllByCreatedBy(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/demo/domain/review/service/ReviewService.java
@@ -10,7 +10,7 @@ import com.example.demo.domain.review.exception.NotFoundReviewException;
 import com.example.demo.domain.review.exception.PurchaseIsNotConfirmedException;
 import com.example.demo.domain.review.mapper.ReviewMapper;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
-import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
+import com.example.demo.domain.review.model.response.ReviewListResponseDTO;
 import com.example.demo.domain.review.repository.ReviewRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -65,13 +65,24 @@ public class ReviewService {
 	}
 
 	@Transactional(readOnly = true)
-	public UserReviewResponseDTO getReviewList(UUID userId, Pageable pageable) {
+	public ReviewListResponseDTO getUserReviewList(UUID userId, Pageable pageable) {
 
 		Page<Review> userReviewList = reviewRepository.findAllByCreatedBy(userId, pageable);
 
-		return new UserReviewResponseDTO(
+		return new ReviewListResponseDTO(
 				userReviewList.getNumberOfElements(),
 				userReviewList.getContent().stream().map(reviewMapper::toReviewResponseDTO).toList()
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public ReviewListResponseDTO getStoreReviewList(UUID storeId, Pageable pageable) {
+
+		Page<Review> storeReviewList = reviewRepository.findAllByIsDeleteTrueAndIsPublicFalseAndOrderStoreId(storeId, pageable);
+
+		return new ReviewListResponseDTO(
+				storeReviewList.getNumberOfElements(),
+				storeReviewList.getContent().stream().map(reviewMapper::toReviewResponseDTO).toList()
 		);
 	}
 
@@ -92,5 +103,4 @@ public class ReviewService {
 			throw new IsNotYourOrderException();
 		}
 	}
-
 }

--- a/src/main/java/com/example/demo/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/demo/domain/review/service/ReviewService.java
@@ -4,14 +4,18 @@ import com.example.demo.domain.entity.common.Status;
 import com.example.demo.domain.order.exception.IsNotYourOrderException;
 import com.example.demo.domain.order.exception.NotFoundOrderException;
 import com.example.demo.domain.order.repository.OrderRepository;
+import com.example.demo.domain.review.entity.Review;
 import com.example.demo.domain.review.exception.IsNotYourReviewException;
 import com.example.demo.domain.review.exception.NotFoundReviewException;
 import com.example.demo.domain.review.exception.PurchaseIsNotConfirmedException;
 import com.example.demo.domain.review.mapper.ReviewMapper;
 import com.example.demo.domain.review.model.request.ReviewRequestDTO;
+import com.example.demo.domain.review.model.response.UserReviewResponseDTO;
 import com.example.demo.domain.review.repository.ReviewRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,6 +62,17 @@ public class ReviewService {
 			throw new NotFoundReviewException();
 		});
 
+	}
+
+	@Transactional(readOnly = true)
+	public UserReviewResponseDTO getReviewList(UUID userId, Pageable pageable) {
+
+		Page<Review> userReviewList = reviewRepository.findAllByCreatedBy(userId, pageable);
+
+		return new UserReviewResponseDTO(
+				userReviewList.getNumberOfElements(),
+				userReviewList.getContent().stream().map(reviewMapper::toReviewResponseDTO).toList()
+		);
 	}
 
 	private void validateReviewByUser(UUID reviewId, UUID userId) {

--- a/src/test/java/com/example/demo/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/demo/domain/order/service/OrderServiceTest.java
@@ -215,7 +215,6 @@ class OrderServiceTest {
 			OrderDetail orderDetail = new OrderDetail();
 			Menu menu = new Menu();
 
-			// Reflection을 사용하여 private 필드 설정
 			ReflectionTestUtils.setField(order, "id", id);
 			ReflectionTestUtils.setField(order, "createdBy", userId);
 			ReflectionTestUtils.setField(menu, "id", menuId);

--- a/src/test/java/com/example/demo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/demo/domain/review/service/ReviewServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain.review.service;
 
+import com.example.demo.domain.entity.Store;
 import com.example.demo.domain.order.entity.Order;
 import com.example.demo.domain.order.exception.IsNotYourOrderException;
 import com.example.demo.domain.order.repository.OrderRepository;
@@ -285,24 +286,33 @@ class ReviewServiceTest {
 
 		private List<Review> createMockReviewList(UUID userId) {
 
+			Store store = new Store();
+			ReflectionTestUtils.setField(store, "id", UUID.randomUUID());
+
+			Order order = new Order();
+			ReflectionTestUtils.setField(order, "id", UUID.randomUUID());
+			ReflectionTestUtils.setField(order, "store", store);
+
 			Review review1 = new Review();
 			ReflectionTestUtils.setField(review1, "id", UUID.randomUUID());
 			ReflectionTestUtils.setField(review1, "content", "Great product!");
 			ReflectionTestUtils.setField(review1, "rating", 5);
 			ReflectionTestUtils.setField(review1, "createdBy", userId);
+			ReflectionTestUtils.setField(review1, "order", order);
 
 			Review review2 = new Review();
 			ReflectionTestUtils.setField(review2, "id", UUID.randomUUID());
 			ReflectionTestUtils.setField(review2, "content", "Not bad.");
 			ReflectionTestUtils.setField(review2, "rating", 3);
 			ReflectionTestUtils.setField(review2, "createdBy", userId);
+			ReflectionTestUtils.setField(review2, "order", order);
 
 			return List.of(review1, review2);
 		}
 
 		@Test
 		@DisplayName("사용자 ID로 작성한 리뷰 목록 조회 성공")
-		void getReviewList_SUCCESS() {
+		void getUserReviewList_SUCCESS() {
 
 			// Given
 			UUID userId = UUID.randomUUID();
@@ -313,10 +323,30 @@ class ReviewServiceTest {
 			when(reviewRepository.findAllByCreatedBy(userId, pageable)).thenReturn(emptyPage);
 
 			// When
-			reviewService.getReviewList(userId, pageable);
+			reviewService.getUserReviewList(userId, pageable);
 
 			// Then
 			verify(reviewRepository, times(1)).findAllByCreatedBy(userId, pageable);
+		}
+
+		@Test
+		@DisplayName("가게 ID로 작성된 리뷰 목록 조회 성공")
+		void getStoreReviewList_SUCCESS() {
+
+			// Given
+			UUID storeId = UUID.randomUUID();
+
+			Pageable pageable = PageRequest.of(0, 10);
+
+			Page<Review> emptyPage = new PageImpl<>(createMockReviewList(UUID.randomUUID()), pageable, 2);
+
+			when(reviewRepository.findAllByIsDeleteTrueAndIsPublicFalseAndOrderStoreId(storeId, pageable)).thenReturn(emptyPage);
+
+			// When
+			reviewService.getStoreReviewList(storeId, pageable);
+
+			// Then
+			verify(reviewRepository, times(1)).findAllByIsDeleteTrueAndIsPublicFalseAndOrderStoreId(storeId, pageable);
 		}
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [#32, #35 ]

## 📝 Description

- 사용자 ID로 작성한 리뷰를 조회하는 기능과 가게 ID로 등록된 리뷰를 조회하는 API 입니다!
- Page 사용해서 실패한 테스트케이스를 떠올리질 못해서 성공 테스트만 작성해두었습니다
- store 의 경우 mock 객체를 사용해서는 isDelete, isPublic 값을 분리하질 못해서 추후 통합테스트에서 진행하려고 합니다

## 💬 To Reivewers

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
